### PR TITLE
Update readme for missing sudo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ Install it from [nodejs.org/download](http://nodejs.org/download)
 Open your terminal and run this command:
 
 ```
-npm install --global javascripting
+sudo npm install --global javascripting
 ```
 
 The `--global` option installs this module globally so that you can run it as a command in your terminal.


### PR DESCRIPTION
Installation of tutorial requires using sudo, this was missing from readme documentation.