### PR TITLE
Updating the language to make more sense.

### DIFF
--- a/problems/if-statement/problem.md
+++ b/problems/if-statement/problem.md
@@ -24,10 +24,10 @@ Create a file named `if-statement.js`.
 
 In that file, declare a variable named `fruit`.
 
-Make the `fruit` variable reference the value **orange**.
+Make the `fruit` variable reference the value **orange** with the type of **String**.
 
-Then use `console.log()` to print **The fruit name has more than five characters.** if the length of the value of `fruit` is greater than five.
-Print **The fruit name has five characters or less.** otherwise.
+Then use `console.log()` to print "**The fruit name has more than five characters."** if the length of the value of `fruit` is greater than five.
+Otherwise, print "**The fruit name has five characters or less.**"
 
 Check to see if your program is correct by running this command:
 


### PR DESCRIPTION
Students were getting caught-up with `.` being a termination for the
text and not for the answer.

`Print x, y, z. and then a, b, c.`
Should be:
`Print "x, y, z." and then "a, b, c."`