### PR TITLE
Fixing empty output problem

### DIFF
--- a/compare-solution.js
+++ b/compare-solution.js
@@ -15,10 +15,8 @@ module.exports = function(solution, attempt, cb) {
 
     run(attempt, function(err, attemptResult) {
 
-      if(err) {
-        if(err.code !== 8) {
-          console.error(err);
-        }
+      if(err && err.code !== 8) {
+        console.error(err);
         return cb(false);
       }
 
@@ -28,7 +26,7 @@ module.exports = function(solution, attempt, cb) {
 
       cb(false, {
         solution: solutionResult,
-        attempt:  attemptResult,
+        attempt:  err || attemptResult,
         diff:     generateDiff(solutionResult, attemptResult)
       });
 


### PR DESCRIPTION
`cb(false)` assumes that the error has been shown before. However if an error `!== 8` is thrown then it will not be shown.